### PR TITLE
solution to issue 87

### DIFF
--- a/sparql-generate-jena/src/main/java/fr/mines_stetienne/ci/sparql_generate/cli/SPARQLExtCli.java
+++ b/sparql-generate-jena/src/main/java/fr/mines_stetienne/ci/sparql_generate/cli/SPARQLExtCli.java
@@ -154,7 +154,8 @@ public class SPARQLExtCli {
 		}
 		try {
 
-			exec(dirFile, r);
+//			exec(dirFile, r);
+			exec(dirFile, r, cl);
 
 			long millis = Duration.between(start, Instant.now()).toMillis();
 			int min = (int) (millis / 60000);


### PR DESCRIPTION
Usage example: 

For query: 

```
BASE <https://ci.mines-stetienne.fr/aqi/data/>
GENERATE {
  <s> <p> ?source .
}
SOURCE <url:sg:source> AS ?source

 ```

The following argument can be added: 

`--source url:sg:source=https://ci.mines-stetienne.fr/aqi/static/station/1`

